### PR TITLE
Refactor for PHP 8.0 compatibility

### DIFF
--- a/fpdi/filters/FilterASCII85_FPDI.php
+++ b/fpdi/filters/FilterASCII85_FPDI.php
@@ -23,7 +23,7 @@ class FilterASCII85_FPDI extends FilterASCII85 {
 
     var $fpdi;
     
-    function FilterASCII85_FPDI(&$fpdi) {
+    public function __construct(&$fpdi) {
         $this->fpdi =& $fpdi;
     }
 

--- a/fpdi/filters/FilterLZW_FPDI.php
+++ b/fpdi/filters/FilterLZW_FPDI.php
@@ -23,7 +23,7 @@ class FilterLZW_FPDI extends FilterLZW {
 
     var $fpdi;
 
-    function FilterLZW_FPDI(&$fpdi) {
+    public function __construct(&$fpdi) {
         $this->fpdi =& $fpdi;
     }
     

--- a/fpdi/fpdi.php
+++ b/fpdi/fpdi.php
@@ -461,10 +461,10 @@ class FPDI extends FPDF_TPL {
 
     			reset ($value[1]);
 
-    			while (list($k, $v) = each($value[1])) {
-    				$this->_straightOut($k . ' ');
-    				$this->pdf_write_value($v);
-    			}
+                foreach ($value[1] as $k => $v) {
+                    $this->_straightOut($k . ' ');
+                    $this->pdf_write_value($v);
+                }
 
     			$this->_straightOut('>>');
     			break;

--- a/fpdi/fpdi_pdf_parser.php
+++ b/fpdi/fpdi_pdf_parser.php
@@ -66,10 +66,10 @@ class fpdi_pdf_parser extends pdf_parser {
      * @param string $filename  Source-Filename
      * @param object $fpdi      Object of type fpdi
      */
-    function fpdi_pdf_parser($filename, &$fpdi) {
+    public function __construct($filename, &$fpdi) {
         $this->fpdi =& $fpdi;
 		
-        parent::pdf_parser($filename);
+        parent::__construct($filename);
 
         // resolve Pages-Dictonary
         $pages = $this->pdf_resolve_object($this->c, $this->root[1][1]['/Pages']);

--- a/fpdi/pdf_context.php
+++ b/fpdi/pdf_context.php
@@ -37,7 +37,7 @@ if (!class_exists('pdf_context', false)) {
     
     	// Constructor
     
-    	function pdf_context(&$f) {
+    	public function __construct(&$f) {
     		$this->file =& $f;
     		if (is_string($this->file))
     		    $this->_mode = 1;

--- a/fpdi/pdf_parser.php
+++ b/fpdi/pdf_parser.php
@@ -98,7 +98,7 @@ if (!class_exists('pdf_parser', false)) {
          *
          * @param string $filename  Source-Filename
          */
-    	function pdf_parser($filename) {
+    	public function __construct($filename) {
             $this->filename = $filename;
             
             $this->f = @fopen($this->filename, 'rb');


### PR DESCRIPTION
Hey there, 

I have put together a fix to make the plugin PHP8 compliant so it can be used in Moodle 4.0 and above. The fix covers:

- Old style constructors deprecated https://www.php.net/manual/en/language.oop5.decon.php
- `Each` method deprecated in PHP-7.4 and removed as of PHP-8 https://www.php.net/manual/en/function.each.php

Regards

Simon